### PR TITLE
Parse TIP and REGISTER commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@celo/base": "^0.0.3",
     "@celo/contractkit": "^0.4.14",
     "probot": "^10.1.0"
   },

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,0 +1,14 @@
+export interface CommandTip {
+  type: 'tip'
+  sender: string
+  receiver: string
+  value: string
+}
+
+export interface CommandRegister {
+  type: 'register'
+  sender: string
+  address: string
+}
+
+export type Command = CommandTip | CommandRegister

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,30 @@
 import { Application } from 'probot' // eslint-disable-line no-unused-vars
 import { Address, ContractKit, newKit } from "@celo/contractkit";
-import { WebhookEvent } from "@octokit/webhooks/dist-types/types";
-import { EventPayloads } from "@octokit/webhooks/dist-types/generated/event-payloads";
+
+import { Command, CommandTip, CommandRegister } from './command'
+import { parseGitHubComment } from './parse'
+
 interface OrgConfig {
   host: string
 }
 
-interface Command {
-  sender: string
-  receiver: string
-  value: number
-}
-
-
-function parseCommand(_context: WebhookEvent<EventPayloads.WebhookPayloadIssueComment>): Command | null  {
+async function getCeloAccountForGithubUsername(_username: string): Promise<Address | null> {
   return null
 }
 
-async function getCeloAccountForGithubUsername(username: string): Address | null {
-  return null
+async function handleCommand(_kit: ContractKit, command: Command) {
+  switch (command.type) {
+    case 'tip':
+      handleTip(_kit, command)
+      break;
+    case 'register':
+      handleRegister(_kit, command)
+      break;
+  }
 }
 
-async function handleCommand(kit: ContractKit, command: Command) {
+async function handleTip(_kit: ContractKit, command: CommandTip) {
+  console.log('Trying to perform tip:', command)
   const senderAddress = await getCeloAccountForGithubUsername(command.sender)
   const recipientAddress = await getCeloAccountForGithubUsername(command.receiver)
 
@@ -30,6 +33,10 @@ async function handleCommand(kit: ContractKit, command: Command) {
   } else {
     console.log("I can't do the transfer")
   }
+}
+
+async function handleRegister(_kit: ContractKit, command: CommandRegister) {
+  console.log('Trying to perform register:', command)
 }
 
 export const app = (app: Application) => {
@@ -42,9 +49,9 @@ export const app = (app: Application) => {
     // @ts-ignore
     const config: OrgConfig = await context.config("celo-tipbot.yml")
     const kit = newKit(config.host)
-    const command = parseCommand(context)
-    if (command) {
-      await handleCommand(kit, command)
+    const result = parseGitHubComment(context.payload.comment)
+    if (result.ok) {
+      await handleCommand(kit, result.result)
     } else {
       console.info("Can't parse the command")
     }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,0 +1,58 @@
+import { EventPayloads } from "@octokit/webhooks/dist-types/generated/event-payloads";
+import { Result, Err, Ok } from '@celo/base/lib/result'
+
+import { Command } from './command'
+import { TokenProcessor } from './token-processor'
+
+function parseTip(sender: string, processor: TokenProcessor): Result<Command, Error> {
+  const result = processor
+    .gitHubUsername('receiver')
+    .number('value')
+    .finish()
+
+  if (result.ok) {
+    return Ok({
+      type: 'tip',
+      sender,
+      receiver: result.result.receiver,
+      value: result.result.value
+    })
+  } else {
+    return result
+  }
+}
+
+function parseRegister(sender: string, processor: TokenProcessor): Result<Command, Error> {
+  const result = processor
+    .address('address')
+    .finish()
+
+  if (result.ok) {
+    return Ok({
+      type: 'register',
+      sender,
+      address: result.result.address
+    })
+  } else {
+    return result
+  }
+}
+
+export function parseGitHubComment(comment: EventPayloads.WebhookPayloadIssueCommentComment): Result<Command, Error> {
+  const sender = comment.user.login
+
+  const processor = TokenProcessor.processString(comment.body)
+    .literal('@celo-tipbot')
+    .identifier('command')
+
+  switch (processor.values.command) {
+    case 'TIP':
+      return parseTip(sender, processor)
+      break;
+    case 'REGISTER':
+      return parseRegister(sender, processor)
+      break;
+    default:
+      return Err(new Error ('Unknown tipbot command'))
+  }
+}

--- a/src/token-processor.ts
+++ b/src/token-processor.ts
@@ -1,0 +1,143 @@
+import { Result, Err, Ok } from '@celo/base/lib/result'
+
+interface ActionConsumeToken {
+  type: 'consume'
+}
+
+const CONSUME: ActionConsumeToken = { type: 'consume' }
+
+interface ActionRememberToken {
+  type: 'remember',
+  key: string,
+  value: string
+}
+
+const REMEMBER = (key: string, value: string): ActionRememberToken => {
+  return {
+    type: 'remember',
+    key,
+    value
+  }
+}
+
+interface ActionError {
+  type: 'error',
+  error: string
+}
+
+const ERROR = (error: string): ActionError => {
+  return {
+    type: 'error',
+    error
+  }
+}
+
+type Action = ActionConsumeToken | ActionRememberToken | ActionError
+
+export interface Values {
+  [key: string]: string
+}
+
+type ProcessorResult = Result<Values, Error>
+
+export class TokenProcessor {
+  error: null | string
+  tokens: string[]
+  currentToken: number
+  values: { [key: string]: string }
+
+  constructor(tokens: string[]) {
+    this.tokens = tokens
+    this.error = null
+    this.currentToken = 0
+    this.values = {}
+  }
+
+  static processString(str: string) {
+    return this.process(str.split(' '))
+  }
+
+  static process(tokens: string[]) {
+    return new TokenProcessor(tokens)
+  }
+
+  finish(): ProcessorResult {
+    if (this.error) {
+      return Err(new Error(this.error))
+    } else {
+      return Ok(this.values)
+    }
+  }
+
+  step(fn: (token: string) => Action) {
+    if (this.error) {
+      return this
+    } else if (this.currentToken >= this.tokens.length) {
+      this.error = 'Critical error in token parser: incomplete command'
+    } else {
+      const action = fn(this.tokens[this.currentToken])
+      switch (action.type) {
+      case 'consume':
+        this.currentToken++
+        break;
+      case 'remember':
+        this.values[action.key] = action.value
+        this.currentToken++
+        break;
+      case 'error':
+        this.error = action.error
+        break;
+      default:
+        this.error = 'Critical error in token parser: unknown action'
+      }
+    }
+
+    return this
+  }
+
+  literal(expected: string) {
+    return this.step((token: string) => {
+      if (token === expected) {
+        return CONSUME
+      } else {
+        return ERROR(`Expected ${expected} but saw ${token}`)
+      }
+    })
+  }
+
+  identifier(id: string) {
+    return this.step((token: string) => {
+      return REMEMBER(id, token)
+    })
+  }
+
+  gitHubUsername(id: string) {
+    return this.step((token: string) => {
+      if (/^@[a-zA-Z0-9\-]+$/.test(token)) {
+        return REMEMBER(id, token.slice(1))
+      } else {
+        return ERROR(`Expected a GitHub username, got ${token}`)
+      }
+    })
+  }
+
+  number(id: string) {
+    return this.step((token: string) => {
+      if (/^(\d+)(\.\d+)?$/.test(token)) {
+        return REMEMBER(id, token)
+      } else {
+        return ERROR(`Expected a number, got ${token}`)
+      }
+    })
+  }
+
+  address(id: string) {
+    return this.step((token: string) => {
+      if (/^0x[0-9a-fA-F]{40}$/.test(token)) {
+        return REMEMBER(id, token)
+      } else {
+        return ERROR(`Expected a Celo address, got ${token}`)
+      }
+    })
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,7 @@
 
 import nock from 'nock'
 // Requiring our app implementation
-import myProbotApp from '../src'
+import { app } from '../src'
 import { Probot, ProbotOctokit } from 'probot'
 // Requiring our fixtures
 import payload from './fixtures/issues.opened.json'
@@ -13,7 +13,7 @@ const path = require('path')
 
 const privateKey = fs.readFileSync(path.join(__dirname, 'fixtures/mock-cert.pem'), 'utf-8')
 
-describe('My Probot app', () => {
+describe('The Celo Tipbot', () => {
   let probot: any
 
   beforeEach(() => {
@@ -28,7 +28,7 @@ describe('My Probot app', () => {
       })
     })
     // Load our app into probot
-    probot.load(myProbotApp)
+    probot.load(app)
   })
 
   test('creates a comment when an issue is opened', async (done) => {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -1,0 +1,96 @@
+import { parseGitHubComment } from '../src/parse'
+
+describe('Command parser', () => {
+  test('parses a correct TIP command', () => {
+    const comment = {
+      user: {
+        login: 'Alice123'
+      },
+      body: '@celo-tipbot TIP @Bob456 10'
+    }
+
+    // @ts-ignore
+    const command = parseGitHubComment(comment)
+    expect(command).toEqual({
+      ok: true,
+      result: {
+        type: 'tip',
+        sender: 'Alice123',
+        receiver: 'Bob456',
+        value: '10'
+      }
+    })
+  })
+
+  test('Fails on a TIP without username', () => {
+    const comment = {
+      user: {
+        login: 'Alice123'
+      },
+      body: '@celo-tipbot TIP 10'
+    }
+
+    // @ts-ignore
+    const command = parseGitHubComment(comment)
+    expect(command.ok).toBeFalsy()
+  })
+
+  test('Fails on a TIP without value', () => {
+    const comment = {
+      user: {
+        login: 'Alice123'
+      },
+      body: '@celo-tipbot TIP @Bob456'
+    }
+
+    // @ts-ignore
+    const command = parseGitHubComment(comment)
+    expect(command.ok).toBeFalsy()
+  })
+
+  test('parses a correct REGISTER command', () => {
+    const comment = {
+      user: {
+        login: 'Alice123'
+      },
+      body: '@celo-tipbot REGISTER 0x5234ae9f990acc920b9209867189eaaee78baf78'
+    }
+
+    // @ts-ignore
+    const command = parseGitHubComment(comment)
+    expect(command).toEqual({
+      ok: true,
+      result: {
+        type: 'register',
+        sender: 'Alice123',
+        address: '0x5234ae9f990acc920b9209867189eaaee78baf78'
+      }
+    })
+  })
+
+  test('fails on a REGISTER with malformed address', () => {
+    const comment = {
+      user: {
+        login: 'Alice123'
+      },
+      body: '@celo-tipbot REGISTER 0x5234ae9f990cc920b9209867189eaaee78baf78'
+    }
+
+    // @ts-ignore
+    const command = parseGitHubComment(comment)
+    expect(command.ok).toBeFalsy()
+  })
+
+  test('Fails on an unknown command', () => {
+    const comment = {
+      user: {
+        login: 'Alice123'
+      },
+      body: '@celo-tipbot DOTHINGS 123'
+    }
+
+    // @ts-ignore
+    const command = parseGitHubComment(comment)
+    expect(command.ok).toBeFalsy()
+  })
+})

--- a/test/token-processor.test.ts
+++ b/test/token-processor.test.ts
@@ -1,0 +1,188 @@
+import { OkResult } from '@celo/base/lib/result'
+
+import { TokenProcessor, Values } from '../src/token-processor'
+
+describe('TokenProcessor', () => {
+  describe('#literal()', () => {
+    test('parses a literal', () => {
+      const result = TokenProcessor.processString('abc')
+        .literal('abc')
+        .finish()
+
+      expect(result.ok).toBeTruthy()
+    })
+
+    test(`fails when the token doesn't match`, () => {
+      const result = TokenProcessor.processString('abc')
+        .literal('def')
+        .finish()
+
+      expect(result.ok).toBeFalsy
+    })
+
+    test('fails when it runs out of tokens', () => {
+      const result = TokenProcessor.processString('abc')
+        .literal('abc')
+        .literal('def')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+  })
+
+  describe('#identifier()', () => {
+    test('parses an identifier', () => {
+      const result = TokenProcessor.processString('bob')
+        .identifier('name')
+        .finish()
+
+      expect(result.ok).toBeTruthy()
+      expect((result as OkResult<Values>).result).toEqual({ name: 'bob' })
+    })
+
+    test('fails when it runs out tokens', () => {
+      const result = TokenProcessor.processString('bob')
+        .identifier('name')
+        .identifier('age')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+  })
+
+  describe('#gitHubUsername()', () => {
+    test('parses a GitHub username', () => {
+      const result = TokenProcessor.processString('@bob')
+        .gitHubUsername('user')
+        .finish()
+
+      expect(result.ok).toBeTruthy()
+      expect((result as OkResult<Values>).result).toEqual({ user: 'bob' })
+    })
+
+    test('fails when not starting with @', () => {
+      const result = TokenProcessor.processString('bob')
+        .gitHubUsername('name')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+
+    test('fails when there are illegal characters', () => {
+      const result = TokenProcessor.processString('@bob#')
+        .gitHubUsername('name')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+
+    test('fails when it runs out tokens', () => {
+      const result = TokenProcessor.processString('@bob')
+        .gitHubUsername('name')
+        .gitHubUsername('age')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+  })
+
+  describe('#number()', () => {
+    test('parses a number', () => {
+      const result = TokenProcessor.processString('123')
+        .number('value')
+        .finish()
+
+      expect(result.ok).toBeTruthy()
+      expect((result as OkResult<Values>).result).toEqual({ value: '123' })
+    })
+
+    test('fails on a non-number', () => {
+      const result = TokenProcessor.processString('a123')
+        .number('value')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+
+    test('fails when it runs out of tokens', () => {
+      const result = TokenProcessor.processString('a123')
+        .number('value')
+        .number('size')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+  })
+
+  describe('#address()', () => {
+    test('parses an address', () => {
+      const result = TokenProcessor.processString('0x0000000CE100000000000000000000000000ce10')
+        .address('address')
+        .finish()
+
+      expect(result.ok).toBeTruthy()
+      expect((result as OkResult<Values>).result).toEqual({ address: '0x0000000CE100000000000000000000000000ce10' })
+    })
+
+    test('fails on a non-hex digit', () => {
+      const result = TokenProcessor.processString('0x0000000CG100000000000000000000000000ce10')
+        .address('address')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+
+    test('fails on a too short string', () => {
+      const result = TokenProcessor.processString('0x0000000CE10000000000000000000000000ce10')
+        .address('address')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+
+    test('fails on a too long string', () => {
+      const result = TokenProcessor.processString('0x0000000CE1000000000000000000000000000ce10')
+        .address('address')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+
+    test('fails when it runs out of tokens', () => {
+      const result = TokenProcessor.processString('0x0000000CE100000000000000000000000000ce10')
+        .address('address')
+        .address('address2')
+        .finish()
+
+
+      expect(result.ok).toBeFalsy()
+    })
+  })
+
+  describe('all together', () => {
+    test('parses multiple types of tokens', () => {
+      const result = TokenProcessor.processString('send bob 123')
+        .literal('send')
+        .identifier('name')
+        .number('value')
+        .finish()
+
+      expect(result.ok).toBeTruthy()
+      expect((result as OkResult<Values>).result).toEqual({
+        name: 'bob',
+        value: '123'
+      })
+    })
+
+    test('fails when it runs out of tokens', () => {
+      const result = TokenProcessor.processString('send bob 123')
+        .literal('send')
+        .identifier('name')
+        .number('value')
+        .literal('bye')
+        .finish()
+
+      expect(result.ok).toBeFalsy()
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,7 +436,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@celo/base@0.0.3":
+"@celo/base@0.0.3", "@celo/base@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@celo/base/-/base-0.0.3.tgz#355199fe45d1f9e667ee66836a34e93828b3b5a5"
   integrity sha512-3GeGcUHCzMxCpkBHywEuoXZp1VV+yN6uEHPowxGgH2VP++qO01HMw8G5J4wlP7jN5HFt3WsZaHWfIhor/irGKg==


### PR DESCRIPTION
Adds a simple linear parser and uses it to parse TIP and REGISTER commands from GitHub comments.